### PR TITLE
fix: semantic import versioning

### DIFF
--- a/mockserver/handler/alarm_callback.go
+++ b/mockserver/handler/alarm_callback.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"net/http"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/alert.go
+++ b/mockserver/handler/alert.go
@@ -7,7 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/alert_condition.go
+++ b/mockserver/handler/alert_condition.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"net/http"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/collector_configuration.go
+++ b/mockserver/handler/collector_configuration.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/collector_configuration_input.go
+++ b/mockserver/handler/collector_configuration_input.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/collector_configuration_output.go
+++ b/mockserver/handler/collector_configuration_output.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/collector_configuration_snippet.go
+++ b/mockserver/handler/collector_configuration_snippet.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/dashboard.go
+++ b/mockserver/handler/dashboard.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/handler.go
+++ b/mockserver/handler/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/index_set.go
+++ b/mockserver/handler/index_set.go
@@ -8,8 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/index_set_stats.go
+++ b/mockserver/handler/index_set_stats.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"net/http"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/index_set_stats_test.go
+++ b/mockserver/handler/index_set_stats_test.go
@@ -3,7 +3,7 @@ package handler_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleGetIndexSetStats(t *testing.T) {

--- a/mockserver/handler/index_set_test.go
+++ b/mockserver/handler/index_set_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/suzuki-shunsuke/go-ptr"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleGetIndexSets(t *testing.T) {

--- a/mockserver/handler/input.go
+++ b/mockserver/handler/input.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/input_test.go
+++ b/mockserver/handler/input_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleGetInput(t *testing.T) {

--- a/mockserver/handler/ldap_setting.go
+++ b/mockserver/handler/ldap_setting.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/not_found_test.go
+++ b/mockserver/handler/not_found_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleNotFound(t *testing.T) {

--- a/mockserver/handler/role.go
+++ b/mockserver/handler/role.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/go-set"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )

--- a/mockserver/handler/role_member.go
+++ b/mockserver/handler/role_member.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/role_member_test.go
+++ b/mockserver/handler/role_member_test.go
@@ -3,7 +3,7 @@ package handler_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleRoleMembers(t *testing.T) {

--- a/mockserver/handler/role_test.go
+++ b/mockserver/handler/role_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/go-set"
 )
 

--- a/mockserver/handler/stream.go
+++ b/mockserver/handler/stream.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/stream_rule.go
+++ b/mockserver/handler/stream_rule.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/stream_rule_test.go
+++ b/mockserver/handler/stream_rule_test.go
@@ -3,7 +3,7 @@ package handler_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleGetStreamRules(t *testing.T) {

--- a/mockserver/handler/stream_test.go
+++ b/mockserver/handler/stream_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	. "github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 	"github.com/suzuki-shunsuke/graylog-mock-server/testutil"
 )

--- a/mockserver/handler/user.go
+++ b/mockserver/handler/user.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/util"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/handler/user_test.go
+++ b/mockserver/handler/user_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestHandleGetUsers(t *testing.T) {

--- a/mockserver/logic/alarm_callback.go
+++ b/mockserver/logic/alarm_callback.go
@@ -1,7 +1,7 @@
 package logic
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlarmCallbacks returns a list of inputs.

--- a/mockserver/logic/alert.go
+++ b/mockserver/logic/alert.go
@@ -3,7 +3,7 @@ package logic
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlert returns an alert.

--- a/mockserver/logic/alert_condition.go
+++ b/mockserver/logic/alert_condition.go
@@ -1,7 +1,7 @@
 package logic
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlertConditions returns a list of alert conditions.

--- a/mockserver/logic/auth.go
+++ b/mockserver/logic/auth.go
@@ -3,7 +3,7 @@ package logic
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // Authenticate authenticates a user.

--- a/mockserver/logic/collector_configuration.go
+++ b/mockserver/logic/collector_configuration.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasCollectorConfiguration returns whether the collector configuration exists.

--- a/mockserver/logic/collector_configuration_input.go
+++ b/mockserver/logic/collector_configuration_input.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasCollectorConfigurationInput returns whether the collector configuration exists.

--- a/mockserver/logic/collector_configuration_output.go
+++ b/mockserver/logic/collector_configuration_output.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasCollectorConfigurationOutput returns whether the collector configuration exists.

--- a/mockserver/logic/collector_configuration_snippet.go
+++ b/mockserver/logic/collector_configuration_snippet.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasCollectorConfigurationSnippet returns whether the collector configuration exists.

--- a/mockserver/logic/dashboard.go
+++ b/mockserver/logic/dashboard.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // AddDashboard adds an dashboard to the mock server.

--- a/mockserver/logic/index_set.go
+++ b/mockserver/logic/index_set.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasIndexSet returns whether the user exists.

--- a/mockserver/logic/index_set_stats.go
+++ b/mockserver/logic/index_set_stats.go
@@ -1,7 +1,7 @@
 package logic
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetIndexSetStats returns an index set stats.

--- a/mockserver/logic/index_set_test.go
+++ b/mockserver/logic/index_set_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/suzuki-shunsuke/go-ptr"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/logic/input.go
+++ b/mockserver/logic/input.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasInput returns whether the input exists.

--- a/mockserver/logic/input_test.go
+++ b/mockserver/logic/input_test.go
@@ -3,8 +3,8 @@ package logic_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/logic/ldap_setting.go
+++ b/mockserver/logic/ldap_setting.go
@@ -1,8 +1,8 @@
 package logic
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // GetLDAPSetting returns a LDAP Setting.

--- a/mockserver/logic/logic.go
+++ b/mockserver/logic/logic.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )

--- a/mockserver/logic/role.go
+++ b/mockserver/logic/role.go
@@ -3,8 +3,8 @@ package logic
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasRole returns whether the role with given name exists.

--- a/mockserver/logic/role_member.go
+++ b/mockserver/logic/role_member.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 const (

--- a/mockserver/logic/role_test.go
+++ b/mockserver/logic/role_test.go
@@ -3,7 +3,7 @@ package logic_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/logic/stream.go
+++ b/mockserver/logic/stream.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasStream returns whether the stream exists.

--- a/mockserver/logic/stream_rule.go
+++ b/mockserver/logic/stream_rule.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 // HasStreamRule returns whether the stream sule exists.

--- a/mockserver/logic/stream_rule_test.go
+++ b/mockserver/logic/stream_rule_test.go
@@ -3,7 +3,7 @@ package logic_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/logic/stream_test.go
+++ b/mockserver/logic/stream_test.go
@@ -3,7 +3,7 @@ package logic_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/logic/user.go
+++ b/mockserver/logic/user.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/suzuki-shunsuke/go-ptr"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/validator"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/validator"
 )
 
 func encryptPassword(password string) string {

--- a/mockserver/logic/user_test.go
+++ b/mockserver/logic/user_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/logic"
 )
 

--- a/mockserver/seed/seed.go
+++ b/mockserver/seed/seed.go
@@ -1,7 +1,7 @@
 package seed
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/go-set"
 )
 

--- a/mockserver/store/plain/alarm_callback.go
+++ b/mockserver/store/plain/alarm_callback.go
@@ -1,7 +1,7 @@
 package plain
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlarmCallbacks returns alarm callbacks.

--- a/mockserver/store/plain/alert.go
+++ b/mockserver/store/plain/alert.go
@@ -1,7 +1,7 @@
 package plain
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // HasAlert returns whether the alert exists.

--- a/mockserver/store/plain/alert_condition.go
+++ b/mockserver/store/plain/alert_condition.go
@@ -1,7 +1,7 @@
 package plain
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlertConditions returns Alert Conditions.

--- a/mockserver/store/plain/collector_configuration.go
+++ b/mockserver/store/plain/collector_configuration.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/collector_configuration_input.go
+++ b/mockserver/store/plain/collector_configuration_input.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/collector_configuration_output.go
+++ b/mockserver/store/plain/collector_configuration_output.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/collector_configuration_snippet.go
+++ b/mockserver/store/plain/collector_configuration_snippet.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/dashboard.go
+++ b/mockserver/store/plain/dashboard.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/index_set.go
+++ b/mockserver/store/plain/index_set.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/index_set_stats.go
+++ b/mockserver/store/plain/index_set_stats.go
@@ -1,7 +1,7 @@
 package plain
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetIndexSetStats returns an index set stats.

--- a/mockserver/store/plain/index_set_test.go
+++ b/mockserver/store/plain/index_set_test.go
@@ -3,7 +3,7 @@ package plain_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )

--- a/mockserver/store/plain/input.go
+++ b/mockserver/store/plain/input.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/input_test.go
+++ b/mockserver/store/plain/input_test.go
@@ -3,7 +3,7 @@ package plain_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )
 

--- a/mockserver/store/plain/ldap_setting.go
+++ b/mockserver/store/plain/ldap_setting.go
@@ -1,7 +1,7 @@
 package plain
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func defaultLDAPSetting() *graylog.LDAPSetting {

--- a/mockserver/store/plain/role.go
+++ b/mockserver/store/plain/role.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // HasRole returns whether the role exists.

--- a/mockserver/store/plain/role_test.go
+++ b/mockserver/store/plain/role_test.go
@@ -3,7 +3,7 @@ package plain_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )
 

--- a/mockserver/store/plain/store.go
+++ b/mockserver/store/plain/store.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/store_test.go
+++ b/mockserver/store/plain/store_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/go-set"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )

--- a/mockserver/store/plain/stream.go
+++ b/mockserver/store/plain/stream.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/stream_rule.go
+++ b/mockserver/store/plain/stream_rule.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/stream_rule_test.go
+++ b/mockserver/store/plain/stream_rule_test.go
@@ -3,7 +3,7 @@ package plain_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )
 

--- a/mockserver/store/plain/stream_test.go
+++ b/mockserver/store/plain/stream_test.go
@@ -3,7 +3,7 @@ package plain_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )

--- a/mockserver/store/plain/user.go
+++ b/mockserver/store/plain/user.go
@@ -3,7 +3,7 @@ package plain
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	st "github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store"
 )
 

--- a/mockserver/store/plain/user_test.go
+++ b/mockserver/store/plain/user_test.go
@@ -3,7 +3,7 @@ package plain_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver/store/plain"
 )
 

--- a/mockserver/store/store.go
+++ b/mockserver/store/store.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // Store manage data.

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/go-ptr"
 	"github.com/suzuki-shunsuke/go-set"
 )

--- a/testutil/test_data_test.go
+++ b/testutil/test_data_test.go
@@ -3,7 +3,7 @@ package testutil_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8/testutil"
 )
 
 func TestRole(t *testing.T) {

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/v8/client"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 


### PR DESCRIPTION
```
$ which replace
replace () {
        ag -l --hidden "$1" | xargs -n 1 gsed -i "s/$1/$2/g"
}

$ replace '"github\.com\/suzuki-shunsuke\/go-graylog' '"github.com\/suzuki-shunsuke\/go-graylog\/v8'
```